### PR TITLE
Fix ban/suspension enforcement (403 set after body write)

### DIFF
--- a/src/comissions.app.api/Middleware/UserMiddleware.cs
+++ b/src/comissions.app.api/Middleware/UserMiddleware.cs
@@ -66,8 +66,10 @@ public class UserMiddleware
             {
                 var suspendDate = suspension.SuspensionDate.ToString("MM/dd/yyyy");
                 var unsuspendDate = suspension.UnsuspensionDate.ToString("MM/dd/yyyy");
-                await context.Response.WriteAsync($"Suspended on {suspendDate} until {unsuspendDate} for {suspension.Reason}.");
+                // Status code must be set before the body is written; once the response
+                // has started the headers are flushed and the status can no longer change.
                 context.Response.StatusCode = StatusCodes.Status403Forbidden;
+                await context.Response.WriteAsync($"Suspended on {suspendDate} until {unsuspendDate} for {suspension.Reason}.");
                 return;
             }
 
@@ -76,8 +78,9 @@ public class UserMiddleware
             {
                 var suspendDate = ban.BanDate.ToString("MM/dd/yyyy");
                 var unsuspendDate = ban.UnbanDate.ToString("MM/dd/yyyy");
-                await context.Response.WriteAsync($"Banned on {suspendDate} until {unsuspendDate} for {ban.Reason}.");
+                // Status code must be set before the body is written (see suspension branch above).
                 context.Response.StatusCode = StatusCodes.Status403Forbidden;
+                await context.Response.WriteAsync($"Banned on {suspendDate} until {unsuspendDate} for {ban.Reason}.");
                 return;
             }
         }


### PR DESCRIPTION
## What
Set the `403 Forbidden` status code **before** writing the response body in both the suspension and ban branches of `UserMiddleware`.

## Why
`Middleware/UserMiddleware.cs` wrote the body first, then set `StatusCode`. Once the body is written the response has started and headers are flushed, so the status assignment was a no-op — banned/suspended users received `200 OK`. Since this middleware is the **only** ban/suspension enforcement point, bans and suspensions did not actually block anything.

## Change
- Suspension branch: `StatusCode = 403` then `WriteAsync(...)`
- Ban branch: same
- Added comments explaining the ordering requirement

## Verification
- `dotnet build comissions.app.api.csproj -c Debug` → `Build succeeded. 0 Error(s), 1 Warning(s)` (the one warning is a pre-existing nullable-reference warning unrelated to this change).
- Manual check to run after merge: authenticate as a banned user and confirm a `403` response (previously `200`).

## Scope
Intentionally minimal — does not address moving DB writes / Novu calls out of this middleware (tracked separately in #14).

Closes #12