### PR TITLE
Lower production log level (Trace → Warning)

### DIFF
--- a/src/comissions.app.api/appsettings.json
+++ b/src/comissions.app.api/appsettings.json
@@ -24,8 +24,8 @@
   },
   "Logging": {
     "LogLevel": {
-      "Default": "Trace",
-      "Microsoft.AspNetCore": "Trace"
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
     }
   },
   "AllowedHosts": "*"


### PR DESCRIPTION
## What
Set base `appsettings.json` logging to `Default=Information`, `Microsoft.AspNetCore=Warning`.

## Why
Base config (used in production) was `Trace`, which logs headers / bearer tokens / PII. The Development override already raises verbosity where wanted.

## Verification
Config-only change (no code). JSON validated.

> 📚 **Stacked PR** — based on `fix/12-ban-status-code` (#25), not `main`. Review/merge #25 first.

Closes #10