### PR TITLE
Move imgcdn API key to configuration

### DIFF
--- a/src/comissions.app.api/Services/Storage/ImgCdnStorageServiceProvider.cs
+++ b/src/comissions.app.api/Services/Storage/ImgCdnStorageServiceProvider.cs
@@ -8,10 +8,12 @@ namespace comissions.app.api.Services.Storage
     public class ImgCdnStorageServiceProvider : IStorageService
     {
         private readonly HttpClient _client;
-        private const string ApiKey = "5386e05a3562c7a8f984e73401540836";
+        private readonly string _apiKey;
 
-        public ImgCdnStorageServiceProvider()
+        public ImgCdnStorageServiceProvider(IConfiguration configuration)
         {
+            _apiKey = configuration.GetValue<string>("Storage:ImgCdn:ApiKey")
+                      ?? throw new InvalidOperationException("Storage:ImgCdn:ApiKey is not configured.");
             _client = new HttpClient { BaseAddress = new Uri("https://imgcdn.dev/") };
         }
 
@@ -22,7 +24,7 @@ namespace comissions.app.api.Services.Storage
                 throw new System.ArgumentNullException(nameof(fileStream));
             }
             using var content = new MultipartFormDataContent();
-            content.Add(new StringContent(ApiKey), "key");
+            content.Add(new StringContent(_apiKey), "key");
             content.Add(new StreamContent(fileStream), "source", fileName);
             
             var response = await _client.PostAsync("api/1/upload", content);

--- a/src/comissions.app.api/appsettings.json
+++ b/src/comissions.app.api/appsettings.json
@@ -16,6 +16,11 @@
     "WebHookSecret": "",
     "ApiKey": ""
   },
+  "Storage": {
+    "ImgCdn": {
+      "ApiKey": ""
+    }
+  },
   "Auth0": {
     "Domain": "https://dev-12mb5yq82dow1twh.us.auth0.com/",
     "Audience": "https://api.artplatform.com",


### PR DESCRIPTION
## What
Remove the hardcoded imgcdn `ApiKey` const from `ImgCdnStorageServiceProvider`; read it from `Storage:ImgCdn:ApiKey` via injected `IConfiguration` (throws if missing). Add the empty key to `appsettings.json`.

## Why
The key was a compile-time constant committed to a public repo.

## Note
The leaked key value must still be **rotated** (tracked in #6) — removing it from source does not un-leak history.

## Verification
`dotnet build` → `Build succeeded. 0 Error(s)` (one pre-existing swagger-tooling warning, unrelated).

> 📚 **Stacked PR** — based on `fix/10-prod-logging` (#26). Merge #25 → #26 → this, in order.

Closes #8