### PR TITLE
Add appsettings.example.json + secrets docs + gitignore guard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -396,3 +396,11 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+
+# Local secrets / config overrides — never commit real secret values.
+# The tracked appsettings.json is kept secret-free; put real values in a
+# local override or environment variables instead.
+appsettings.Local.json
+appsettings.*.Local.json
+**/appsettings.Local.json
+**/appsettings.*.Local.json

--- a/README.md
+++ b/README.md
@@ -48,6 +48,29 @@ docker run -p 8080:80 art-platform
 
 The API should be accessible at `http://localhost:8080`.
 
+## Configuration
+
+Application settings are read from `appsettings.json` (and environment-specific
+overrides). **Do not commit real secrets.** Copy the template and fill in your
+own values locally, or supply them via environment variables / a secret store:
+
+```bash
+cp src/comissions.app.api/appsettings.example.json src/comissions.app.api/appsettings.json
+```
+
+Secrets configured via this file or env vars include:
+
+| Key | Description |
+| --- | --- |
+| `Database:username` / `Database:password` | Postgres credentials (required — the app fails to start if unset) |
+| `Stripe:ApiKey` / `Stripe:WebHookSecret` | Stripe secret key and webhook signing secret |
+| `Auth0:ClientId` / `Auth0:ClientSecret` | Auth0 application credentials |
+| `Storage:ImgCdn:ApiKey` | imgcdn upload key |
+| `Novu:ApiKey` | Novu notifications key |
+
+Environment variables use the standard .NET double-underscore convention,
+e.g. `Database__password`, `Stripe__ApiKey`.
+
 ## Usage
 
 Describe how to use your API and any specific details or considerations that users need to be aware of.

--- a/src/comissions.app.api/appsettings.example.json
+++ b/src/comissions.app.api/appsettings.example.json
@@ -1,0 +1,37 @@
+{
+  "UI": {
+    "BaseUrl": "http://localhost:3000"
+  },
+  "Novu": {
+    "ApiKey": ""
+  },
+  "Database": {
+    "Database": "comissionsapp",
+    "Host": "localhost",
+    "Port": 5432,
+    "username": "",
+    "password": ""
+  },
+  "Stripe": {
+    "WebHookSecret": "",
+    "ApiKey": ""
+  },
+  "Storage": {
+    "ImgCdn": {
+      "ApiKey": ""
+    }
+  },
+  "Auth0": {
+    "Domain": "https://your-tenant.us.auth0.com/",
+    "Audience": "https://your-api-audience",
+    "ClientId": "",
+    "ClientSecret": ""
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
## What
- Add `appsettings.example.json` — a copy-me template with every config key and empty secret values.
- Document configuration & secrets (and the `Database__password` env-var convention) in the README.
- Add a `.gitignore` guard for `appsettings.Local.json` override files.

## Why
There was no template and no guard against re-committing secrets. The tracked `appsettings.json` stays secret-free; real values go in a local override or env vars.

## Verification
Docs/config only — no code change. JSON validated.

> 📚 **Stacked PR** — based on `fix/9-db-cred-fallbacks` (#28). This is the top of the M1 (Secrets & Config) chain.

Closes #11