### PR TITLE
Add rate limiting and HSTS

### DIFF
--- a/src/comissions.app.api/Program.cs
+++ b/src/comissions.app.api/Program.cs
@@ -36,6 +36,25 @@ builder.Services.Configure<Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServe
     options.Limits.MaxRequestBodySize = 10 * 1024 * 1024;
 });
 builder.Services.AddEndpointsApiExplorer();
+
+// Basic per-client fixed-window rate limiting to blunt abuse / brute force.
+builder.Services.AddRateLimiter(options =>
+{
+    options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+    options.GlobalLimiter = System.Threading.RateLimiting.PartitionedRateLimiter.Create<HttpContext, string>(context =>
+    {
+        var partitionKey = context.User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value
+                           ?? context.Connection.RemoteIpAddress?.ToString()
+                           ?? "anonymous";
+        return System.Threading.RateLimiting.RateLimitPartition.GetFixedWindowLimiter(partitionKey, _ =>
+            new System.Threading.RateLimiting.FixedWindowRateLimiterOptions
+            {
+                PermitLimit = 100,
+                Window = TimeSpan.FromMinutes(1),
+                QueueLimit = 0
+            });
+    });
+});
 builder.Services.AddSingleton<ApplicationDatabaseConfigurationModel>();
 builder.Services.AddDbContext<ApplicationDbContext>();
 builder.Services.AddSwaggerGen(options =>
@@ -153,6 +172,12 @@ builder.Services.AddCors(options =>
 
 var app = builder.Build();
 
+// Enforce HSTS outside development.
+if (!app.Environment.IsDevelopment())
+{
+    app.UseHsts();
+}
+
 var dbContext = app.Services.GetService<ApplicationDbContext>();
 dbContext.Database.Migrate();
 app.UseSwagger();
@@ -168,6 +193,7 @@ defaultFilesOptions.DefaultFileNames.Clear();
 defaultFilesOptions.DefaultFileNames.Add("index.html"); // replace 'yourf
 app.UseStaticFiles();
 app.UseHttpsRedirection();
+app.UseRateLimiter();
 app.UseCors(CorsPolicyName);
 app.UseAuthentication();
 app.UseMiddleware<UserMiddleware>();


### PR DESCRIPTION
## What
- Built-in ASP.NET Core rate limiter: per-user (falls back to per-IP) fixed window, 100 req/min, `429` on exceed; `UseRateLimiter` wired into the pipeline.
- `UseHsts()` enabled outside development.

## Why
No rate limiting or HSTS existed. (Downloads already use `application/octet-stream`, which mitigates stored XSS — left as-is.)

## Verification
`dotnet build` → `Build succeeded. 0 Error(s)`.

## Note
A global limiter is a sane default; per-endpoint policies (tighter limits on uploads/writes) can be layered later.

> 📚 **Stacked PR** — based on `fix/18-upload-limits` (#36). Top of the M4 chain.

Closes #19