### PR TITLE
Return 404 instead of 500 for missing user row

### DIFF
--- a/src/comissions.app.api/Controllers/UserController.cs
+++ b/src/comissions.app.api/Controllers/UserController.cs
@@ -23,7 +23,9 @@ public class UserController : Controller
     public async Task<IActionResult> GetUser()
     {
         var userId = User.GetUserId();
-        var user = await _dbContext.Users.FirstAsync(user=>user.Id==userId);
+        var user = await _dbContext.Users.FirstOrDefaultAsync(user=>user.Id==userId);
+        if(user==null)
+            return NotFound();
         var result = user.ToModel();
         return Ok(result);
     }
@@ -33,8 +35,10 @@ public class UserController : Controller
     public async Task<IActionResult> UpdateUser(UserInfoUpdateModel model)
     {
         var userId = User.GetUserId();
-        var existingUser = await _dbContext.Users.FirstAsync(user=>user.Id==userId);
-        
+        var existingUser = await _dbContext.Users.FirstOrDefaultAsync(user=>user.Id==userId);
+        if(existingUser==null)
+            return NotFound();
+
         if(_dbContext.Users.Any(x=>x.DisplayName==model.DisplayName && x.Id!=userId))
             return BadRequest("Display name is already in use.");
         


### PR DESCRIPTION
## What
`UserController.GetUser` / `UpdateUser` used `FirstAsync` (throws -> 500 when no row). Switched to `FirstOrDefaultAsync` + `NotFound()`.

## Verification
`dotnet build` -> Build succeeded, 0 errors.

> Stacked PR — based on `fix/14-middleware-perf` (#31).

Closes #16