### PR TITLE
Gate startup migration behind config flag + DI scope

### DIFF
--- a/src/comissions.app.api/Program.cs
+++ b/src/comissions.app.api/Program.cs
@@ -178,8 +178,15 @@ if (!app.Environment.IsDevelopment())
     app.UseHsts();
 }
 
-var dbContext = app.Services.GetService<ApplicationDbContext>();
-dbContext.Database.Migrate();
+// Applying migrations on startup races when multiple replicas boot together and
+// is best handled by the dedicated migrator job. Gate it behind a config flag
+// (default off) and resolve the DbContext from a scope rather than the root provider.
+if (builder.Configuration.GetValue<bool>("Database:RunMigrationsOnStartup"))
+{
+    using var migrationScope = app.Services.CreateScope();
+    var dbContext = migrationScope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+    dbContext.Database.Migrate();
+}
 app.UseSwagger();
 app.UseSwaggerUI(settings =>
 {


### PR DESCRIPTION
## What
- Gate auto-migration behind `Database:RunMigrationsOnStartup` (default **false**).
- Resolve `ApplicationDbContext` from a created scope via `GetRequiredService` instead of the root provider.

## Why
`Program.cs` resolved a scoped DbContext from the root provider and ran `Database.Migrate()` on every boot, which races across replicas. Schema migrations should run via the dedicated `comissions.app.database.migrator` job.

## Verification
`dotnet build` -> Build succeeded, 0 errors.

> Stacked PR — based on `fix/19-ratelimit-hsts` (#33). Top of the stack.

Closes #15