### PR TITLE
Use decimal/integer cents for money instead of double

### DIFF
--- a/src/comissions.app.api/Controllers/ArtistRequestsController.cs
+++ b/src/comissions.app.api/Controllers/ArtistRequestsController.cs
@@ -330,7 +330,7 @@ public class ArtistRequestsController: Controller
         if (request.Declined)
             return BadRequest("Request has already been declined.");
 
-        var paymentUrl = _paymentService.Charge(request.Id,request.Artist.StripeAccountId,Convert.ToDouble(request.Amount));
+        var paymentUrl = _paymentService.Charge(request.Id,request.Artist.StripeAccountId,request.Amount);
         request.Accepted = true;
         request.AcceptedDate = DateTime.UtcNow;
         request.Paid = false;

--- a/src/comissions.app.api/Controllers/CustomerRequestsController.cs
+++ b/src/comissions.app.api/Controllers/CustomerRequestsController.cs
@@ -74,7 +74,7 @@ public class CustomerRequestsController : Controller
             if (request != null && request.Accepted && !request.Declined && !request.Completed &&
                 request.Artist.StripeAccountId == connectedAccountId)
             {
-                var paymentUrl = _paymentService.Charge(request.Id,request.Artist.StripeAccountId,Convert.ToDouble(request.Amount));
+                var paymentUrl = _paymentService.Charge(request.Id,request.Artist.StripeAccountId,request.Amount);
                 request.PaymentUrl = paymentUrl;
                 _dbContext.Entry(request).State = EntityState.Modified;
                 await _dbContext.SaveChangesAsync();
@@ -773,7 +773,7 @@ public class CustomerRequestsController : Controller
         if(request==null)
             return NotFound();
         if(request.PaymentUrl==null)
-            request.PaymentUrl = _paymentService.Charge(request.Id,request.Artist.StripeAccountId,Convert.ToDouble(request.Amount));
+            request.PaymentUrl = _paymentService.Charge(request.Id,request.Artist.StripeAccountId,request.Amount);
         _dbContext.Entry(request).State = EntityState.Modified;
         _dbContext.SaveChanges();
         return Ok(new {paymentUrl = request.PaymentUrl});

--- a/src/comissions.app.api/Models/PayoutModel.cs
+++ b/src/comissions.app.api/Models/PayoutModel.cs
@@ -4,8 +4,8 @@ public class PayoutModel
 {
     public int PayoutDelayDays { get; set; }
     public string Interval { get; set; }
-    public double Balance { get; set; }
+    public decimal Balance { get; set; }
     public bool Enabled { get; set; }
     public string PayoutUrl { get; set; }
-    public double PendingBalance { get; set; }
+    public decimal PendingBalance { get; set; }
 }

--- a/src/comissions.app.api/Services/Payment/IPaymentService.cs
+++ b/src/comissions.app.api/Services/Payment/IPaymentService.cs
@@ -9,9 +9,9 @@ public interface IPaymentService
     string CreateArtistAccount();
     string CreateArtistAccountOnboardingUrl(string accountId); 
     bool ArtistAccountIsOnboarded(string accountId);
-    string Charge(int orderArtistServiceId, string? sellerStripeAccountId, double orderPrice);
+    string Charge(int orderArtistServiceId, string? sellerStripeAccountId, decimal orderPrice);
     string CreateDashboardUrl(string accountId);
     Account GetAccount(string? artistStripeAccountId);
-    double GetBalance(string accountId);
-    double GetPendingBalance(string accountId);
+    decimal GetBalance(string accountId);
+    decimal GetPendingBalance(string accountId);
 }

--- a/src/comissions.app.api/Services/Payment/StripePaymentServiceProvider.cs
+++ b/src/comissions.app.api/Services/Payment/StripePaymentServiceProvider.cs
@@ -88,9 +88,10 @@ public class StripePaymentServiceProvider:IPaymentService
     }
 
     public string Charge(int requestId, string? sellerStripeAccountId,
-        double requestAmount)
+        decimal requestAmount)
     {
-        var feeAmount = (long)Math.Round((requestAmount*0.05) * 100);
+        // Work in integer cents; Stripe expects the smallest currency unit.
+        var feeAmount = (long)Math.Round(requestAmount * 0.05m * 100m, MidpointRounding.AwayFromZero);
         var options = new Stripe.Checkout.SessionCreateOptions
         {
             LineItems = new List<Stripe.Checkout.SessionLineItemOptions> {
@@ -98,7 +99,7 @@ public class StripePaymentServiceProvider:IPaymentService
                     {
                         PriceData = new Stripe.Checkout.SessionLineItemPriceDataOptions
                         {
-                            UnitAmount = (long)Math.Round(requestAmount * 100),
+                            UnitAmount = (long)Math.Round(requestAmount * 100m, MidpointRounding.AwayFromZero),
                             Currency = "usd",
                             ProductData = new Stripe.Checkout.SessionLineItemPriceDataProductDataOptions
                             {
@@ -143,22 +144,23 @@ public class StripePaymentServiceProvider:IPaymentService
         return account;
     }
     
-    public double GetBalance(string accountId)
+    public decimal GetBalance(string accountId)
     {
         var balanceService = new BalanceService();
         var balance = balanceService.Get(new RequestOptions()
         {
             StripeAccount = accountId
         });
-        return balance.Available[0].Amount/100;
+        // Stripe amounts are in integer cents; convert to a decimal currency amount without loss.
+        return balance.Available[0].Amount / 100m;
     }
-    public double GetPendingBalance(string accountId)
+    public decimal GetPendingBalance(string accountId)
     {
         var balanceService = new BalanceService();
         var balance = balanceService.Get(new RequestOptions()
         {
             StripeAccount = accountId
         });
-        return balance.Pending[0].Amount/100;
+        return balance.Pending[0].Amount / 100m;
     }
 }


### PR DESCRIPTION
## What
- `IPaymentService.Charge` / `GetBalance` / `GetPendingBalance` now use `decimal`.
- `StripePaymentServiceProvider` converts to Stripe integer-cent `long` only at the boundary (`Math.Round(..., AwayFromZero)`); balance getters divide by `100m` (no lossy integer division).
- `PayoutModel.Balance` / `PendingBalance` → `decimal`.
- Callers pass `request.Amount` directly (dropped `Convert.ToDouble`).

## Why
Money should not round-trip through binary floating point.

## Verification
`dotnet build` → Build succeeded, 0 errors.

> Based on the freshly purged `main`. Independent of #23/#24.

Closes #22