### PR TITLE
Remove ResolveConflictingActions crutch; normalize Artist route

### DIFF
--- a/src/comissions.app.api/Controllers/ArtistController.cs
+++ b/src/comissions.app.api/Controllers/ArtistController.cs
@@ -14,7 +14,7 @@ using Novu.DTO.Events;
 namespace comissions.app.api.Controllers;
 
 [ApiController]
-[Route("api/[controller]")]
+[Route("api/Artist")]
 public class ArtistController : Controller
 {
     private readonly ApplicationDbContext _dbContext;

--- a/src/comissions.app.api/Program.cs
+++ b/src/comissions.app.api/Program.cs
@@ -65,7 +65,6 @@ builder.Services.AddSwaggerGen(options =>
         Version = "v1.0",
         Description = ""
     });
-    options.ResolveConflictingActions(x => x.First());
     options.AddSecurityDefinition("oauth2", new OpenApiSecurityScheme
     {
         Type = SecuritySchemeType.OAuth2,


### PR DESCRIPTION
## What
- Normalize `ArtistController` from `[Route("api/[controller]")]` to `[Route("api/Artist")]` (resolves to the same path — **not** API-breaking).
- Remove `options.ResolveConflictingActions(x => x.First())` from Swagger setup so genuine route conflicts surface instead of being silently swallowed.

## Why
There were no real route collisions — all 15 Artist actions are distinct on path+verb. The crutch was masking doc-level ambiguity from the inconsistent base-route declaration.

## Verification
Generated `swagger.json` with the crutch removed: **exit 0, 0 conflicting-action errors, 75 paths**, all `api/Artist*` routes present. (`dotnet build` also clean.)

> Stacked on `fix/22-money-decimal` (#39).

Closes #23