### PR TITLE
Fix 500 on GET /api/Discovery/Artists/{id} (missing .Include(User))

### DIFF
--- a/src/comissions.app.api/Controllers/DiscoveryController.cs
+++ b/src/comissions.app.api/Controllers/DiscoveryController.cs
@@ -39,6 +39,7 @@ public class DiscoveryController : Controller
     public async Task<IActionResult> GetArtist(int sellerId)
     {
         var seller = await _dbContext.UserArtists
+            .Include(x=>x.User)
             .FirstOrDefaultAsync(x=>x.Id==sellerId);
         if(seller==null)
             return NotFound();


### PR DESCRIPTION
## What
Add `.Include(x=>x.User)` to `DiscoveryController.GetArtist`.

## Why
The query didn't eager-load `User`, but `ToDiscoveryModel()` reads `seller.User.DisplayName` → `NullReferenceException` → **HTTP 500** for every artist-by-id request. Found by running the app, not static review. The sibling list and by-name endpoints already include `User`.

## Verification (live, against a seeded artist)
| Request | Before | After |
| --- | --- | --- |
| `GET /api/Discovery/Artists/1` | 500 | **200** (full body) |
| `GET /api/Discovery/Artists/999` | — | **404** |

`dotnet build` clean.

Closes #42