### PR TITLE
Fix 500 on first authenticated request (User.AdminNotes NOT NULL)

### DIFF
--- a/src/comissions.app.api/Entities/User.cs
+++ b/src/comissions.app.api/Entities/User.cs
@@ -12,7 +12,7 @@ public record User
     public string Email { get; set; } = null!;
     
     public int? UserArtistId { get; set; }
-    public string AdminNotes { get; set; }
+    public string AdminNotes { get; set; } = string.Empty;
     [JsonIgnore] public virtual UserArtist? UserArtist { get; set; }
     [JsonIgnore] public virtual ICollection<Request> Requests { get; set; } = new List<Request>();
     [JsonIgnore] public virtual ICollection<Suspension> Suspensions { get; set; } = new List<Suspension>();


### PR DESCRIPTION
## What
Initialize `User.AdminNotes = string.Empty` on the entity.

## Why
`AdminNotes` was a non-nullable `string` with no initializer → defaulted to `null`. `UserMiddleware` auto-creates a user without setting it, so EF inserted `NULL`, violating the NOT NULL column constraint → **HTTP 500 on the first authenticated request for any new user** (blocks all onboarding). Found by running the app with a real token.

## Verification (live)
`GET /api/User` with a valid bearer token → **200**, user auto-created (was 500).

Closes #44